### PR TITLE
feat: export css file

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
 		".": {
 			"import": "./dist/ui-library.es.js",
 			"require": "./dist/ui-library.umd.js"
-		}
+		},
+		"./dist/style.css": "./dist/style.css"
 	},
 	"dependencies": {
 		"classnames": "^2.3.1",


### PR DESCRIPTION
This is required so that applications can actually include the CSS. Alternatively, it is also possible to import through `node_modules`, but I feel like that's not the clean solution.