### PR TITLE
ci: add release action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,28 @@
+name: 'release'
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: 'Semver version to bump'
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '16'
+
+      - run: npm ci
+      - run: npm version ${{ github.event.inputs.bump }} --no-git-tag-version
+      - run: npm run build
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Very basic action to get going. Basically, one can choose if it's a patch, minor or major bump, and the action will release the new version to npm. No commitlint, releases or automatic SemVer for now.