### PR TITLE
ci: fix release action (commit bump and registry)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,6 +19,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: '16'
+          registry-url: 'https://registry.npmjs.org'
 
       - run: npm ci
       - run: npm version ${{ github.event.inputs.bump }} --no-git-tag-version
@@ -26,3 +27,14 @@ jobs:
       - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - id: get-version
+        run: |
+          echo ::set-output name=version::$(node -pe "require('./package.json')['version']")
+
+      - uses: EndBug/add-and-commit@v9
+        with:
+          add: 'package.json package-lock.json'
+          default_author: github_actor
+          message: 'chore: bump to v${{ steps.get-version.outputs.version }}'
+          push: true


### PR DESCRIPTION
Two things were missing:
- The registry in `actions/setup-node@v3` that sets `.npmrc` up to use `NODE_AUTH_TOKEN` (https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#publish-to-npmjs-and-gpr-with-npm)
- Commiting the `package.json` with bumped version