### PR TITLE
build: replace broken husky with simple-git-hooks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
 				"eslint-plugin-prettier": "^4.2.1",
 				"json": "^11.0.0",
 				"postcss-nesting": "^10.1.10",
+				"simple-git-hooks": "^2.8.0",
 				"typescript": "^4.7.4",
 				"vite": "^2.9.14",
 				"vite-plugin-dts": "^1.3.0"
@@ -17804,6 +17805,16 @@
 			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
 			"dev": true
 		},
+		"node_modules/simple-git-hooks": {
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/simple-git-hooks/-/simple-git-hooks-2.8.0.tgz",
+			"integrity": "sha512-ocmZQORwa6x9mxg+gVIAp5o4wXiWOHGXyrDBA0+UxGKIEKOyFtL4LWNKkP/2ornQPdlnlDGDteVeYP5FjhIoWA==",
+			"dev": true,
+			"hasInstallScript": true,
+			"bin": {
+				"simple-git-hooks": "cli.js"
+			}
+		},
 		"node_modules/sisteransi": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -34750,6 +34761,12 @@
 			"version": "3.0.7",
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
 			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+			"dev": true
+		},
+		"simple-git-hooks": {
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/simple-git-hooks/-/simple-git-hooks-2.8.0.tgz",
+			"integrity": "sha512-ocmZQORwa6x9mxg+gVIAp5o4wXiWOHGXyrDBA0+UxGKIEKOyFtL4LWNKkP/2ornQPdlnlDGDteVeYP5FjhIoWA==",
 			"dev": true
 		},
 		"sisteransi": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
 		"eslint-plugin-prettier": "^4.2.1",
 		"json": "^11.0.0",
 		"postcss-nesting": "^10.1.10",
+		"simple-git-hooks": "^2.8.0",
 		"typescript": "^4.7.4",
 		"vite": "^2.9.14",
 		"vite-plugin-dts": "^1.3.0"
@@ -87,22 +88,10 @@
 	"eslintIgnore": [
 		"build/*"
 	],
-	"husky": {
-		"hooks": {
-			"pre-commit": "lint-staged"
-		}
+	"simple-git-hooks": {
+		"pre-commit": "npx lint-staged"
 	},
 	"lint-staged": {
-		"linters": {
-			"*.{js,jsx,json,ts,tsx,css,md,html}": [
-				"prettier --write",
-				"git add"
-			]
-		},
-		"ignore": [
-			"node_modules",
-			"dist",
-			"package-lock.json"
-		]
+		"*.{js,jsx,json,ts,tsx,css,md,html}": "prettier --write"
 	}
 }


### PR DESCRIPTION
So, the husky config actually didn't even work, and I'm not a huge fan of how the new versions work, which is why I'm replacing it with https://github.com/toplenboren/simple-git-hooks.