### PR TITLE
ci: fix release bump commit

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,20 +25,19 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - run: npm ci
-      - run: npm version ${{ github.event.inputs.bump }} --no-git-tag-version
+      - id: bump
+        run: |
+          VERSION=$(npm version ${{ github.event.inputs.bump }} --no-git-tag-version)
+          echo ::set-output name=version::$VERSION
 
       - uses: EndBug/add-and-commit@v9
         with:
           add: 'package.json package-lock.json'
           default_author: github_actor
-          message: 'chore: bump to v${{ steps.get-version.outputs.version }}'
+          message: 'chore: bump to ${{ steps.bump.outputs.version }}'
           push: 'origin main --set-upstream --force'
 
       - run: npm run build
       - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-      - id: get-version
-        run: |
-          echo ::set-output name=version::$(node -pe "require('./package.json')['version']")


### PR DESCRIPTION
I foolishly moved the bump commit above the `get-version` step, which resulted in the broken commit message in https://github.com/swarmcity/ui-library/commit/89f7e1bd47764c38463e66c637135cfd1d2be709. This should fix that issue.