### PR TITLE
feat: replace open in collapse with expand component

### DIFF
--- a/src/icon-button/icon-button.module.css
+++ b/src/icon-button/icon-button.module.css
@@ -33,6 +33,7 @@ button.icon {
 	&.disabled,
 	&:disabled {
 		pointer-events: none;
+
 		&::before {
 			opacity: 0.2;
 		}
@@ -63,6 +64,7 @@ button.icon {
 		mask-image: url('./images/icon-logout.svg');
 		mask-size: 36px;
 		background-color: var(--secondary-color-3);
+
 		@media (min-width: 992px) {
 			mask-size: 50px;
 		}
@@ -72,6 +74,7 @@ button.icon {
 		mask-image: url('./images/icon-back.svg');
 		mask-size: 36px;
 		background-color: var(--secondary-color-3);
+
 		@media (min-width: 992px) {
 			mask-size: 50px;
 		}
@@ -80,6 +83,7 @@ button.icon {
 	&.select {
 		width: 36px;
 		height: 36px;
+
 		&::before {
 			mask-image: url('./images/icon-next.svg');
 			mask-size: 36px;
@@ -94,6 +98,7 @@ button.icon {
 	&.confirmDanger {
 		width: 72px;
 		height: 72px;
+
 		&::before {
 			mask-size: 56px !important;
 		}
@@ -122,6 +127,7 @@ button.icon {
 
 	&.requestNext {
 		background-color: #24b1ff;
+
 		&::before {
 			mask-image: url('./images/icon-next.svg');
 			background-color: var(--base);
@@ -146,6 +152,7 @@ button.icon {
 	&.confirmSend {
 		width: 50px;
 		height: 50px;
+
 		&::before {
 			mask-image: url('./images/icon-confirm.svg');
 			mask-size: 38px !important;
@@ -156,9 +163,17 @@ button.icon {
 	&.collapse {
 		transform: rotate(270deg);
 		transition: transform 0.3s;
-		&.open {
-			transform: rotate(90deg);
+
+		&::before {
+			mask-image: url('./images/icon-next.svg');
+			background-color: var(--action-bg-color);
 		}
+	}
+
+	&.expand {
+		transform: rotate(90deg);
+		transition: transform 0.3s;
+
 		&::before {
 			mask-image: url('./images/icon-next.svg');
 			background-color: var(--action-bg-color);
@@ -185,6 +200,7 @@ button.icon {
 	&.chat {
 		width: 80px;
 		height: 80px;
+
 		&::before {
 			mask-size: 62px;
 		}
@@ -196,6 +212,7 @@ button.icon {
 		font-size: 10px;
 		background-color: var(--secondary-color-4);
 		color: var(--base);
+
 		&::before {
 			content: none;
 		}
@@ -205,10 +222,12 @@ button.icon {
 		background-color: #24b1ff;
 		width: 20px;
 		height: 20px;
+
 		@media screen and (min-width: 768px) {
 			width: 30px;
 			height: 30px;
 		}
+
 		&::before {
 			mask-image: url('./images/icon-new.svg');
 			background-color: var(--base);
@@ -220,6 +239,7 @@ button.icon {
 		background-color: #191919;
 		width: 30px;
 		height: 30px;
+
 		&::before {
 			mask-image: url('./images/icon-upload.svg');
 			mask-size: 23px;

--- a/src/icon-button/icon-button.stories.tsx
+++ b/src/icon-button/icon-button.stories.tsx
@@ -24,6 +24,7 @@ export default {
 				'confirmSend',
 				'counter',
 				'exit',
+				'expand',
 				'reply',
 				'requestNext',
 				'requestStart',
@@ -40,11 +41,6 @@ export default {
 		},
 		disabled: {
 			name: 'Disable',
-			control: 'boolean',
-			defaultValue: false,
-		},
-		open: {
-			name: 'Toggle (collapse only)',
 			control: 'boolean',
 			defaultValue: false,
 		},

--- a/src/icon-button/icon-button.tsx
+++ b/src/icon-button/icon-button.tsx
@@ -11,6 +11,7 @@ const VARIANTS = {
 	exit: classes.exit,
 	back: classes.back,
 	collapse: classes.collapse,
+	expand: classes.expand,
 	select: classes.select,
 	conflictNext: classes.conflictNext,
 	requestNext: classes.requestNext,
@@ -28,13 +29,11 @@ const VARIANTS = {
 export type IconButtonProps = h.JSX.HTMLAttributes<HTMLButtonElement> & {
 	variant?: keyof typeof VARIANTS
 	disabled?: boolean
-	open?: boolean
 }
 
 export const IconButton = ({
 	children,
 	variant,
-	open,
 	disabled,
 	class: className,
 	...props
@@ -43,7 +42,6 @@ export const IconButton = ({
 		class={cn(
 			classes.icon,
 			variant && VARIANTS[variant],
-			open && classes.open,
 			disabled && classes.disabled,
 			className
 		)}


### PR DESCRIPTION
Usually in UI libraries you would have these two split. It also removes the `open` prop which is really only usable in the collapse component and ignored in other variants.